### PR TITLE
Refactor: Pass `accountId` as navigation argument to Account Entry Sc…

### DIFF
--- a/app/src/main/java/com/seyone22/expensetracker/ui/navigation/ExpenseNavGraph.kt
+++ b/app/src/main/java/com/seyone22/expensetracker/ui/navigation/ExpenseNavGraph.kt
@@ -179,7 +179,9 @@ fun ExpenseNavHost(
 
 
         // Routes to pages for CRUD operations
-        composable(route = AccountEntryDestination.route, enterTransition = {
+        composable(route = AccountEntryDestination.route + "/{accountId}",
+            arguments = listOf(navArgument("accountId") { type = NavType.StringType }),
+            enterTransition = {
             slideInHorizontally(animationSpec = tween(500),
                 initialOffsetX = { fullWidth -> fullWidth } // Slide in from the right
             ) + fadeIn(animationSpec = tween(500))
@@ -192,7 +194,9 @@ fun ExpenseNavHost(
                 navigateBack = { navController.popBackStack() },
                 onNavigateUp = { navController.navigateUp() },
                 navigateToScreen = { screen -> navController.navigate(screen) },
-                accountId = ""
+                accountId = if (it.arguments?.getString("accountId") == "") null else it.arguments?.getString(
+                    "accountId"
+                )
             )
         }
         composable(


### PR DESCRIPTION
…reen

- Modified the route for `AccountEntryDestination` to accept an optional `accountId` as a navigation argument.
- Updated the `composable` function to extract `accountId` from navigation arguments.
- If the `accountId` passed is empty, it is set as null, otherwise it's value is used.
- Updated `accountId` to be passed as a parameter in `AccountEntryScreen`
- Added `navArgument` to define the `accountId` argument type as `NavType.StringType`.